### PR TITLE
Fix clip path with hash in url

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -8,6 +8,9 @@ module.exports = {
 			options: {
 				preserve: true
 			}
+		},
+		'clip-path': {
+			message: 'ignores clip-path with hash in url'
 		}
 	}
 };

--- a/index.js
+++ b/index.js
@@ -34,13 +34,13 @@ export default postcss.plugin('postcss-color-hex-alpha', opts => {
 });
 
 // match any hexa
-const alphaHexRegExp = /#([0-9A-f]{4}(?:[0-9A-f]{4})?)\b/;
+const alphaHexRegExp = /#([0-9A-Fa-f]{4}(?:[0-9A-Fa-f]{4})?)\b/;
 
 // whether a node has a hexa
 const hasAlphaHex = node => alphaHexRegExp.test(node.value);
 
 // match an exact hexa
-const alphaHexValueRegExp = /^#([0-9A-f]{4}(?:[0-9A-f]{4})?)$/;
+const alphaHexValueRegExp = /^#([0-9A-Fa-f]{4}(?:[0-9A-Fa-f]{4})?)$/;
 
 // walk all nodes in a value
 const walk = (node, fn) => {

--- a/test/clip-path.css
+++ b/test/clip-path.css
@@ -1,0 +1,3 @@
+#svg-element {
+	clip-path: url(#SVGID_1_);
+}

--- a/test/clip-path.expect.css
+++ b/test/clip-path.expect.css
@@ -1,0 +1,3 @@
+#svg-element {
+	clip-path: url(#SVGID_1_);
+}


### PR DESCRIPTION
RegExp to find color looking values is not very specific. So underscores (_) are allowed in RegExp that leads to NaN in output. Making RegExp more specific fixes this issue.

Old behaviour:
`clip-path: url(#SVGID_1_);` compiles to `url(rgba(NaN,NaN,13,0.00392));`

New behaviour:
`clip-path: url(#SVGID_1_);` compiles to `clip-path: url(#SVGID_1_);`