### PR TITLE
chore(repo): remove use of npx + update eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
     }
   },
   "scripts": {
-    "build": "npx rollup -c .rollup.js",
-    "build:watch": "npx rollup -c .rollup.js --watch",
-    "lint": "npx eslint --cache src",
-    "lint:fix": "npx eslint --cache --fix",
+    "build": "rollup -c .rollup.js",
+    "build:watch": "rollup -c .rollup.js --watch",
+    "lint": "eslint --cache src",
+    "lint:fix": "eslint --cache --fix",
     "pretest": "npm install && npm run build",
     "test": "npm run lint && npm run tape",
-    "tape": "npx postcss-tape",
+    "tape": "postcss-tape",
     "prepublishOnly": "npm test"
   },
   "engines": {
@@ -43,11 +43,11 @@
     "@babel/core": "^7.15.5",
     "@babel/preset-env": "^7.15.6",
     "@rollup/plugin-babel": "^5.3.0",
-    "eslint": "^7.32.0",
+    "eslint": "^8.0.1",
     "postcss": "^8.3.7",
     "postcss-tape": "^6.0.1",
     "pre-commit": "^1.2.2",
-    "rollup": "^2.57.0",
+    "rollup": "^2.58.0",
     "rollup-plugin-copy": "^3.4.0"
   },
   "eslintConfig": {


### PR DESCRIPTION
Update dependencies after spotted a comment about babel-eslint in this previous pr

https://github.com/postcss/postcss-color-hex-alpha/pull/15

One question is around the post css peeDependency, would you prefer to bump that too?
